### PR TITLE
Remove msgpack-jruby of gemspec. its no longer updated and part of th…

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Contributors:
 * Nick Ethier (nickethier)
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
+* Matthias Wilhelm (kertal)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ bin/plugin install --no-verify
 
 ## Contributing
 
-All contributions are welcome: ideas, patches, documentation, bug reports, complaints, and even something you drew up on a napkin.
+All contributions are welcome: ideas, patches, documentation, bug reports, complaints and even something you drew up on a napkin.
 
-Programming is not a required skill. Whatever you've seen about open source and maintainers or community members  saying "send patches or die" - you will not see that here.
+Programming is not a required skill. Whatever you've seen about open source and maintainers or community members saying "send patches or die" - you will not see that here.
 
 It is more important to the community that you are able to contribute.
 

--- a/logstash-codec-msgpack.gemspec
+++ b/logstash-codec-msgpack.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
 
   if RUBY_PLATFORM == "java"
     s.platform = RUBY_PLATFORM
-    s.add_runtime_dependency "msgpack-jruby"  #(Apache 2.0 license)
-  else
-    s.add_runtime_dependency "msgpack"        #(Apache 2.0 license)
   end
+
+  s.add_runtime_dependency "msgpack" #(Apache 2.0 license)
+
   s.add_development_dependency 'logstash-devutils'
 end
 


### PR DESCRIPTION
Had a problem with some messages where MessagePack.unpack threw 

`java.io.IOException: Invalid byte: -39`

Solved it by removing msgpack-jruby, which is no longer maintained and now part of the msgpack-ruby gem. 
