### PR TITLE
#5 fix msgpack version to ~> 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Constrain msgpack dependency to ~> 1.1 due to old versions not containing some format and type definitions
+
 ## 3.0.5
   - Fix some documentation issues
 

--- a/logstash-codec-msgpack.gemspec
+++ b/logstash-codec-msgpack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-msgpack'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Encode and decode msgpack formatted data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-codec-msgpack.gemspec
+++ b/logstash-codec-msgpack.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.email           = 'info@elastic.co'
   s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths   = ["lib"]
+  s.platform        = "java"
 
   # Files
   s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]
@@ -22,12 +23,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  if RUBY_PLATFORM == "java"
-    s.platform = RUBY_PLATFORM
-    s.add_runtime_dependency "msgpack-jruby"  #(Apache 2.0 license)
-  else
-    s.add_runtime_dependency "msgpack"        #(Apache 2.0 license)
-  end
+  s.add_runtime_dependency 'msgpack', '~> 1.1'
   s.add_development_dependency 'logstash-devutils'
 end
 


### PR DESCRIPTION
 Upgraded/Locked in `msgpack` at `~>1.1`. Note that there is no separate `msgpack-jruby` anymore for recent versions => I had to move to the `msgpack` gem for the "java" platform.
Also, we're "java" platform only now => removed the platform conditional :)

All in all, same as and bringing us in alignment with https://github.com/logstash-plugins/logstash-codec-fluent/pull/13 