### PR TITLE
Feat: target configuration + event-factory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Feat: added target configuration + event-factory support [#13](https://github.com/logstash-plugins/logstash-codec-msgpack/pull/13)
+
 ## 3.0.7
   - Update gemspec summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.0
   - Feat: added target configuration + event-factory support [#13](https://github.com/logstash-plugins/logstash-codec-msgpack/pull/13)
+  - Fix: decoding to create a fallback event when msg-pack unpacking fails
 
 ## 3.0.7
   - Update gemspec summary

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,12 +23,13 @@ include::{include_path}/plugin_header.asciidoc[]
 This codec reads and produces MessagePack encoded content.
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Msgpack Codec Configuration Options
+==== Msgpack Codec configuration options
 
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-format>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
 &nbsp;
@@ -37,8 +38,27 @@ This codec reads and produces MessagePack encoded content.
 ===== `format` 
 
   * Value type is <<string,string>>
-  * Default value is `nil`
+  * There is no default value for this setting.
 
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Define the target field for placing the decoded values. If this setting is not
+set, data will be stored at the root (top level) of the event.
+
+For example, if you want data to be put under the `document` field:
+[source,ruby]
+    input {
+      tcp {
+        port => 4242
+        codec => msgpack {
+          target => "[document]"
+        }
+      }
+    }
 
 
 

--- a/lib/logstash/codecs/msgpack.rb
+++ b/lib/logstash/codecs/msgpack.rb
@@ -4,14 +4,23 @@ require "logstash/timestamp"
 require "logstash/util"
 
 require 'logstash/plugin_mixins/event_support/event_factory_adapter'
+require 'logstash/plugin_mixins/validator_support/field_reference_validation_adapter'
 
 class LogStash::Codecs::Msgpack < LogStash::Codecs::Base
+
+  extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
 
   include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
 
   config_name "msgpack"
 
   config :format, :validate => :string, :default => nil
+
+  # Defines a target field for placing decoded fields.
+  # If this setting is omitted, data gets stored at the root (top level) of the event.
+  #
+  # NOTE: the target is only relevant while decoding data into a new event.
+  config :target, :validate => :field_reference
 
   public
   def register
@@ -22,7 +31,7 @@ class LogStash::Codecs::Msgpack < LogStash::Codecs::Base
   def decode(data)
     begin
       # Msgpack does not care about UTF-8
-      event = event_factory.new_event(MessagePack.unpack(data))
+      event = targeted_event_factory.new_event(MessagePack.unpack(data))
       
       if @format && event.get("message").nil?
         event.set("message", event.sprintf(@format))

--- a/logstash-codec-msgpack.gemspec
+++ b/logstash-codec-msgpack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-msgpack'
-  s.version         = '3.0.8'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads MessagePack encoded content"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_runtime_dependency 'msgpack', '~> 1.1'
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-codec-msgpack.gemspec
+++ b/logstash-codec-msgpack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-msgpack'
-  s.version         = '3.0.7'
+  s.version         = '3.0.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads MessagePack encoded content"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
 
   s.add_runtime_dependency 'msgpack', '~> 1.1'
   s.add_development_dependency 'logstash-devutils'

--- a/spec/codecs/msgpack_spec.rb
+++ b/spec/codecs/msgpack_spec.rb
@@ -5,26 +5,49 @@ require "logstash/event"
 require "insist"
 
 describe LogStash::Codecs::Msgpack do
-  subject do
-    next LogStash::Codecs::Msgpack.new
-  end
+
+  subject { LogStash::Codecs::Msgpack.new(config) }
+
+  let(:config) { Hash.new }
+
+  let(:data) { { "foo" => "bar", "baz" => { "bah" => ["a","b","c"] }, "@timestamp" => "2014-05-30T02:52:17.929Z" } }
 
   context "#decode" do
+
     it "should return an event from msgpack data" do
-      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}, "@timestamp" => "2014-05-30T02:52:17.929Z"}
+      event_count = 0
       subject.decode(MessagePack.pack(data)) do |event|
+        event_count += 1
         insist { event.is_a? LogStash::Event }
         insist { event.get("foo") } == data["foo"]
         insist { event.get("baz") } == data["baz"]
         insist { event.get("bah") } == data["bah"]
         insist { event.get("@timestamp").to_iso8601 } == data["@timestamp"]
       end
+      expect(event_count).to eql 1
+    end
+
+    context 'with target' do
+
+      let(:config) { super().merge('target' => '[doc]') }
+
+      it "decodes an event" do
+        event_count = 0
+        subject.decode(MessagePack.pack(data)) do |event|
+          event_count += 1
+          expect(event.include?("foo")).to be false
+          expect(event.get("[doc][foo]")).to eql 'bar'
+          expect(event.get("[doc][baz]")).to eql "bah" => ["a","b","c"]
+          expect(event.get("[doc][@timestamp]")).to eql data["@timestamp"]
+        end
+        expect(event_count).to eql 1
+      end
+
     end
   end
 
   context "#encode" do
     it "should return msgpack data from pure ruby hash" do
-      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}, "@timestamp" => "2014-05-30T02:52:17.929Z"}
       event = LogStash::Event.new(data)
       got_event = false
       subject.on_event do |e, d|
@@ -36,7 +59,7 @@ describe LogStash::Codecs::Msgpack do
         got_event = true
       end
       subject.encode(event)
-      insist { got_event }
+      expect(got_event).to be true
     end
 
     it "should return msgpack data from deserialized json with normalization" do


### PR DESCRIPTION
PR adds the `target` option - to be able to "isolate" fields created decoded by the codec.
also fix-ed decoding to create a fallback event on msg-pack errors (like other codecs do)
